### PR TITLE
Ignore all [MSG:] from grbl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "grbl-streamer"
 authors = [
   {name = "Michael Franzl", email = "public.michael@franzl.name"},
 ]
-version = "2.0.0"
+version = "2.0.1"
 description = "Universal interface module written in Python 3 for the grbl CNC firmware"
 readme = "README.md"
 requires-python = ">=3.5"

--- a/src/grbl_streamer/__init__.py
+++ b/src/grbl_streamer/__init__.py
@@ -878,14 +878,15 @@ class GrblStreamer:
                     pass
 
                 elif re.match(r'^\[...:.*', line):
-                    self._update_hash_state(line)
                     self._callback('on_read', line)
+                    if "'$H'|'$X' to unlock" not in line: #[MSG:'$H'|'$X' to unlock]
+                        self._update_hash_state(line)
 
-                    if 'PRB' in line:
-                        # last line
-                        self._callback('on_hash_stateupdate', self.settings_hash)
-                        self.preprocessor.cs_offsets = self.settings_hash
-                        self._callback('on_probe', self.settings_hash['PRB'])
+                        if 'PRB' in line:
+                            # last line
+                            self._callback('on_hash_stateupdate', self.settings_hash)
+                            self.preprocessor.cs_offsets = self.settings_hash
+                            self._callback('on_probe', self.settings_hash['PRB'])
 
                 elif 'ALARM' in line:
                     # grbl for some reason doesn't respond to ? polling


### PR DESCRIPTION
Hi, I was getting runtime errors in the _onread() thread due to the following push message from my machine:

`[MSG:'$H'|'$X' to unlock]`

The line was being processed by _update_hash_state() and throwing an exception.

I am proposing adding this wildcard catch of [MSG:] lines, of which there are a number in the latest versions of Grbl.

https://github.com/gnea/grbl/blob/master/doc/markdown/interface.md#message-summary